### PR TITLE
Add active class to navigation links based on current page user is on

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -22,10 +22,10 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="{% url 'vacation_list' %}">Vacations</a>
+                        <a class="nav-link {% if request.resolver_match.url_name == 'vacation_list' %}active{% endif %}" href="{% url 'vacation_list' %}">Vacations</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{% url 'create_vacation' %}">Add Vacation</a>
+                        <a class="nav-link {% if request.resolver_match.url_name == 'create_vacation' %}active{% endif %}" href="{% url 'create_vacation' %}">Add Vacation</a>
                     </li>
                     {% if user.is_authenticated %}
                     <li class="nav-item">
@@ -33,7 +33,7 @@
                     </li>
                     {% else %}
                     <li class="nav-item">
-                        <a class="nav-link" href="{% url 'login' %}">Login</a>
+                        <a class="nav-link {% if request.resolver_match.url_name == 'login' %}active{% endif %}" href="{% url 'login' %}">Login</a>
                     </li>
                     {% endif %}
                     {% if user.is_authenticated %}


### PR DESCRIPTION
This pull request enhances the navigation menu items. The navigation bar were not being highlighted on the active page, which were confusing users about their current location. Which has been resolved now.

Screenshots : 
![Screenshot 2025-05-07 at 9 02 07 PM](https://github.com/user-attachments/assets/017d3a42-2e30-4161-93b6-3a77f3279c39)
![Screenshot 2025-05-07 at 9 01 59 PM](https://github.com/user-attachments/assets/557a3ab9-08cc-42a6-a3ea-3c717601bf13)


