### PR TITLE
Fix: Dynamically display current year in footer using Django template tag

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -69,7 +69,7 @@
 
     <!-- Footer -->
     <footer class="bg-light text-center mt-5 py-3">
-        <p class="mb-0">&copy; <strong>{% now "Y" %}</strong><strong>Organisize</strong>.
+        <p class="mb-0">&copy; <strong>{% now "Y" %}</strong> <strong>Organisize</strong>.
             All rights reserved.</p>
     </footer>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,7 +69,7 @@
 
     <!-- Footer -->
     <footer class="bg-light text-center mt-5 py-3">
-        <p class="mb-0">&copy; <strong>{{ year }}</strong> <strong>Organisize</strong>.
+        <p class="mb-0">&copy; <strong>{% now "Y" %}</strong><strong>Organisize</strong>.
             All rights reserved.</p>
     </footer>
 


### PR DESCRIPTION
## Description
- This PR fixes a bug where the {{ year }} variable in the footer was undefined due to it not being passed from the view context.
- To resolve this, I replaced the undefined variable with Django's built-in {% now "Y" %} template tag, which dynamically renders the year.

## Changes Made:
- Updated footer template in templates/base.html to use {% now "Y" %} instead of {{ year }}

## Testing:
- Verified that the current year renders correctly in the footer on all pages without requiring changes to the view logic.